### PR TITLE
adding support for web.archive.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Install on [brave/chrome](https://chrome.google.com/webstore/detail/uniform-time
 | Discord   | ✅*     |                                                                                                                                                  |
 | Instagram | ✅      |                                                                                                                                                  |
 | Bluesky   | ✅*     | works only for english translation of the platform, hard to expand                                                                               |
+| Wayback Machine   | ✅     | |
 | Linkedin  | TODO   | come help! [Linkedin-post-timestamp-extractor](https://ollie-boyd.github.io/Linkedin-post-timestamp-extractor/)                                  |
 | Youtube   | TODO   | come help! it requires the official API (see [amnesty youtube dataviewer](https://citizenevidence.amnestyusa.org/)) / and possibly file metadata |
 | Facebook  | TODO   | come help!                                                                                                                                       |

--- a/source/css/hover-popup.css
+++ b/source/css/hover-popup.css
@@ -61,6 +61,7 @@
 	margin-left: auto;
 	/* margin-right: auto; */
 	display: inline-block;
+	color: initial;
 }
 
 .timezone-fixer-popup a {

--- a/source/js/fixer.js
+++ b/source/js/fixer.js
@@ -59,7 +59,7 @@ class Fixer {
 			for (const node of this.getNodes(target)) {
 				try {
 					// eslint-disable-next-line no-new
-					new HoverPopup(target.attachTo(node), target.timestamp(node), target.url(node));
+					new HoverPopup(target.attachTo(node), target.timestamp(node), target.label ?? 'post', target.url(node));
 				} catch (error) {
 					console.error('failed to process node:', error, node);
 				} finally {

--- a/source/js/hover-popup.js
+++ b/source/js/hover-popup.js
@@ -11,19 +11,21 @@ class HoverPopup {
 	 * @param {DateTime} timeData Date/string instance with timezone information
 	 * @param {int} hoverDelay defaults to 200
 	 * @param {int} hoverAfter defaults to 500
-	 * @param {string} postUrl defaults to empty string - if included adds a link to the popup
+	 * @param {string} resourceLabel defaults to empty string - if included used as a label for the resourceUrl
+	 * @param {string} resourceUrl defaults to empty string - if included adds a link to the popup
 	 */
-	constructor(attachTo, timeData, postUrl = '', hoverDelay = 200, hoverAfter = 500) {
+	constructor(attachTo, timeData, resourceLabel = '', resourceUrl = '', hoverDelay = 200, hoverAfter = 500) {
 		console.log(`received timeData=${timeData} for ${attachTo}`);
 		this.moment = moment(timeData);
-		chrome.runtime.sendMessage({action: 'store-data', data: {url: postUrl, time: this.moment.tz('UTC').format()}});
+		chrome.runtime.sendMessage({action: 'store-data', data: {url: resourceUrl, time: this.moment.tz('UTC').format()}});
 		this.element = attachTo;
 		this.version = chrome.runtime.getManifest().version;
 
 		// Optional parameters
 		this.hoverDelay = hoverDelay;
 		this.hoverAfter = hoverAfter;
-		this.postUrl = postUrl;
+		this.resourceUrl = resourceUrl;
+		this.resourceLabel = resourceLabel
 
 		this.hoverTimeout = null;
 		this.isHovered = false;
@@ -132,7 +134,7 @@ class HoverPopup {
 			</tbody>
 		</table>
 
-		${this.postUrl ? `<small>post: <a href="${this.postUrl}" title="link to post">${this.postUrl}</a> - <a href="#!" class="copy-time-value" copy-value="${this.postUrl}" title="click to copy to clipboard">copy</a><small/>` : ''}
+		${this.resourceUrl ? `<small>${this.resourceLabel}: <a href="${this.resourceUrl}" title="link to resource">${this.resourceUrl}</a> - <a class="copy-time-value" copy-value="${this.resourceUrl}" title="click to copy to clipboard">copy</a><small/>` : ''}
 
 		<hr/>
 

--- a/source/js/hover-popup.js
+++ b/source/js/hover-popup.js
@@ -25,7 +25,7 @@ class HoverPopup {
 		this.hoverDelay = hoverDelay;
 		this.hoverAfter = hoverAfter;
 		this.resourceUrl = resourceUrl;
-		this.resourceLabel = resourceLabel
+		this.resourceLabel = resourceLabel;
 
 		this.hoverTimeout = null;
 		this.isHovered = false;
@@ -121,7 +121,7 @@ class HoverPopup {
 			</thead>
 			<tbody>
 
-			${moments.map(m => `<tr class="time-item"><td title="${m.description}">${m.timezone}</td><td><a href="#!" class="copy-time-value" copy-value="${m.timeStr}" title="click to copy to clipboard">${m.timeStr}</a></td></tr>`).join('')}
+			${moments.map(m => `<tr class="time-item"><td title="${m.description}">${m.timezone}</td><td><a class="copy-time-value" copy-value="${m.timeStr}" title="click to copy to clipboard">${m.timeStr}</a></td></tr>`).join('')}
 
 			<tr id="custom-${this.randomId}">
 				<td>
@@ -129,7 +129,7 @@ class HoverPopup {
 					${moment.tz.names().map(tz => `<option value="${tz}">${tz}</option>`).join('')}
 					</select>
 				</td>
-				<td class="time-item"><a href="#!" class="copy-time-value" copy-value="DYNAMIC" title="click to copy to clipboard"></a></td>
+				<td class="time-item"><a class="copy-time-value" copy-value="DYNAMIC" title="click to copy to clipboard"></a></td>
 			</tr>
 			</tbody>
 		</table>

--- a/source/js/timezone-fixers/web-archive.js
+++ b/source/js/timezone-fixers/web-archive.js
@@ -1,0 +1,50 @@
+import Fixer from '../fixer.js';
+
+/**
+ * This script enables uniform timestamps for web.archive.org.
+ * Timestamps handled by this script:
+ *   - start and end date of snapshots in WayBack Machine's calendar view
+ *     - saved n times between <start date> and <end date>
+ *     - div.captures-range-info a[href^="/web/"]
+ *   - time of capture shown at the top of the calendar view
+ *     - a.capture-link[href^="/web/"]
+ *   - time of crawl in WayBack Machine's calendar view
+ *     - a.snapshot-link[href^="/web/"]
+*/
+const fixer = new Fixer('WayBackMachine', [
+	{
+		name: 'Time of Crawl',
+		selector: 'div.captures-range-info a[href^="/web/"], a.capture-link[href^="/web/"], a.snapshot-link[href^="/web/"]',
+		attachTo: node => node,
+		timestamp: node => {
+            // href = "/web/20230304105925/example.com"
+            const timestamp = node.getAttribute('href').match(/\/web\/(\d+)\//);
+            if(timestamp && timestamp[1]){
+                return parseWayBackMachineDateString(timestamp[1]);
+            } else {
+                return null;
+            }
+        },
+		url(node) {
+			// `https://web.archive.org/web/20230304105925/example.com`
+			return `https://web.archive.org${node.getAttribute('href')}`;
+		},
+        label: 'snapshot',
+	},
+]);
+
+fixer.start();
+
+const parseWayBackMachineDateString = (dateString) => {
+    // dateString = "20230304105925"
+    if (typeof dateString !== "string" || !/^\d{14}$/.test(dateString)) return null;
+
+    const year = parseInt(dateString.substring(0, 4), 10);
+    const month = parseInt(dateString.substring(4, 6), 10) - 1;
+    const day = parseInt(dateString.substring(6, 8), 10);
+    const hours = parseInt(dateString.substring(8, 10), 10);
+    const minutes = parseInt(dateString.substring(10, 12), 10);
+    const seconds = parseInt(dateString.substring(12, 14), 10);
+    return new Date(Date.UTC(year, month, day, hours, minutes, seconds)).toISOString();
+}
+

--- a/source/js/timezone-fixers/web-archive.js
+++ b/source/js/timezone-fixers/web-archive.js
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import Fixer from '../fixer.js';
 
 /**
@@ -16,35 +17,31 @@ const fixer = new Fixer('WayBackMachine', [
 		name: 'Time of Crawl',
 		selector: 'div.captures-range-info a[href^="/web/"], a.capture-link[href^="/web/"], a.snapshot-link[href^="/web/"]',
 		attachTo: node => node,
-		timestamp: node => {
-            // href = "/web/20230304105925/example.com"
-            const timestamp = node.getAttribute('href').match(/\/web\/(\d+)\//);
-            if(timestamp && timestamp[1]){
-                return parseWayBackMachineDateString(timestamp[1]);
-            } else {
-                return null;
-            }
-        },
+		timestamp(node) {
+			// Href = "/web/20230304105925/example.com"
+			const timestamp = node.getAttribute('href').match(/\/web\/(\d+)\//);
+			if (timestamp && timestamp[1]) {
+				return parseWayBackMachineDateString(timestamp[1]);
+			}
+
+			return null;
+		},
 		url(node) {
 			// `https://web.archive.org/web/20230304105925/example.com`
 			return `https://web.archive.org${node.getAttribute('href')}`;
 		},
-        label: 'snapshot',
+		label: 'snapshot',
 	},
 ]);
 
 fixer.start();
 
-const parseWayBackMachineDateString = (dateString) => {
-    // dateString = "20230304105925"
-    if (typeof dateString !== "string" || !/^\d{14}$/.test(dateString)) return null;
+const parseWayBackMachineDateString = dateString => {
+	// DateString = "20230304105925"
+	if (typeof dateString !== 'string' || !/^\d{14}$/.test(dateString)) {
+		return null;
+	}
 
-    const year = parseInt(dateString.substring(0, 4), 10);
-    const month = parseInt(dateString.substring(4, 6), 10) - 1;
-    const day = parseInt(dateString.substring(6, 8), 10);
-    const hours = parseInt(dateString.substring(8, 10), 10);
-    const minutes = parseInt(dateString.substring(10, 12), 10);
-    const seconds = parseInt(dateString.substring(12, 14), 10);
-    return new Date(Date.UTC(year, month, day, hours, minutes, seconds)).toISOString();
-}
+	return moment(dateString, 'YYYYMMDDHHmmss').utc();
+};
 

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -43,6 +43,11 @@
 		"js": ["js/timezone-fixers/bluesky.js"],
 		"css": ["css/hover-popup.css"],
 		"run_at": "document_end"
+	}, {
+		"matches": ["https://web.archive.org/web/*/*"],
+		"js": ["js/timezone-fixers/web-archive.js"],
+		"css": ["css/hover-popup.css"],
+		"run_at": "document_end"
 	}],
 	"action": {
 		"default_popup": "html/popup.html"

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Uniform Timezone Extension",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"description": "Brings standardization to social media posts' dates and times.",
 	"homepage_url": "https://github.com/bellingcat/uniform-timezone",
 	"manifest_version": 3,


### PR DESCRIPTION
PR for Issue #19 

- new fixer for web.archive.org
- updated css for select tag in popup to use "initial" color. the color style for select tag on web.archive.org is applied to the popup as well and the text is being rendered in white on white background. Hence the css change 
- started passing label as well from the Fixer along with url. used "snapshot" as label for the web.archive.org link and renamed related vars to be agnostic of post/snapshot
 
Demo:

https://github.com/bellingcat/uniform-timezone/assets/49707819/16231c52-5df6-4750-81b2-779678702fd4