### PR TITLE
Fixes issues in the LinkdeIn extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install on [brave/chrome](https://chrome.google.com/webstore/detail/uniform-time
 | Instagram | ✅      |                                                                                                                                                  |
 | Bluesky   | ✅*     | works only for english translation of the platform, hard to expand                                                                               |
 | Wayback Machine   | ✅     | |
-| Linkedin  | ✅*   | works for time info, not for URL extraction |
+| Linkedin  | ✅*   | works for comments and post (posts only on the post page, not in the feed) |
 | Youtube   | TODO   | come help! it requires the official API (see [amnesty youtube dataviewer](https://citizenevidence.amnestyusa.org/)) / and possibly file metadata |
 | Facebook  | TODO   | come help!                                                                                                                                       |
 | GitHub    | TODO   | come help!                                                                                                                                       |

--- a/source/js/timezone-fixers/linkedin.js
+++ b/source/js/timezone-fixers/linkedin.js
@@ -15,8 +15,9 @@ const fixer = new Fixer('LinkedIn', [
 		selector: 'span.update-components-actor__sub-description > span',
 		attachTo: node => node,
 		timestamp: getPublicationTimestamp,
+		filterSelected: checkPostUrl,
 		label: 'publication',
-		url: _ => null,
+		url: _ => window.location.origin + window.location.pathname,
 	},
 	{
 		name: 'Comment Timestamp',
@@ -28,13 +29,15 @@ const fixer = new Fixer('LinkedIn', [
 	},
 ]);
 
-function getPublicationTimestamp(node) {
-	// TODO: try to get it from URL
-	const parnt = node.closest('.feed-shared-update-v2');
-	if (parnt.getAttributeNames().includes('data-urn')) {
-		const _id = Number.parseInt(parnt.dataset.urn.split(':')[3], 10);
-		const first41Bits = Number.parseInt((_id).toString(2).slice(0, 41), 2);
-		return moment.unix(first41Bits / 1000);
+function getPublicationTimestamp(_) {
+	if (document.URL.startsWith('https://www.linkedin.com/posts/')) {
+		const linkedinURL = document.URL;
+		const regex = /(\d{19})/;
+		const postId = regex.exec(linkedinURL)?.pop();
+		if (postId !== undefined) {
+			const first41Bits = Number.parseInt((Number.parseInt(postId, 10)).toString(2).slice(0, 41), 2);
+			return moment.unix(first41Bits / 1000);
+		}
 	}
 
 	return null;
@@ -60,6 +63,10 @@ function getCommentUrl(node) {
 	}
 
 	return null;
+}
+
+function checkPostUrl(_) {
+	return document.URL.startsWith('https://www.linkedin.com/posts/');
 }
 
 fixer.start();


### PR DESCRIPTION
As described here  #3, the time for post publication in the feed is actually the time of repost in many cases. To avoid that, this PR:
* Doesn't show the post time in the feed but only in the post page based on the URL
* Still shows the timestamp of comments

I think it is better to have nothing displayed in the feed rather than people mixing up repost time and publication time and making wrong hypothesis based on it.

I have also updated the README to make it clear (and linted the js this time ;) )