### PR TITLE
Adds support for threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Install on [brave/chrome](https://chrome.google.com/webstore/detail/uniform-time
 | Bluesky   | ✅*     | works only for english translation of the platform, hard to expand                                                                               |
 | Wayback Machine   | ✅     | |
 | Linkedin  | ✅*   | works for comments, posts, and feed items |
+| Threads   | ✅      |                                                                                                                                                  |
 | Youtube   | TODO   | come help! it requires the official API (see [amnesty youtube dataviewer](https://citizenevidence.amnestyusa.org/)) / and possibly file metadata |
 | Facebook  | TODO   | come help!                                                                                                                                       |
 | GitHub    | TODO   | come help!                                                                                                                                       |
@@ -85,6 +86,10 @@ How to use? Hover over any time element on the page.
 How to use? Hover over any time element on the page.
 
  * Does not extract the POST URLs, and the comment URLs are references but can't always be resolved/opened.
+
+### Threads ✅
+How to use?
+1. Hover over any time element on the page.
 
 ---
 

--- a/source/css/hover-popup.css
+++ b/source/css/hover-popup.css
@@ -61,7 +61,8 @@
 	margin-left: auto;
 	/* margin-right: auto; */
 	display: inline-block;
-	color: initial;
+	color: black;
+	background: #fff;
 }
 
 .timezone-fixer-popup a {

--- a/source/css/hover-popup.css
+++ b/source/css/hover-popup.css
@@ -61,7 +61,7 @@
 	margin-left: auto;
 	/* margin-right: auto; */
 	display: inline-block;
-	color: black;
+	color: #000;
 	background: #fff;
 }
 

--- a/source/js/timezone-fixers/threads.js
+++ b/source/js/timezone-fixers/threads.js
@@ -1,0 +1,17 @@
+import Fixer from '../fixer.js';
+
+/**
+ * This script enables uniform timestamps for threads.com
+ * Timestamps handled by this script: ALL
+*/
+const fixer = new Fixer('Threads', [
+	{
+		name: 'Post Timestamp',
+		selector: 'time',
+		attachTo: node => node,
+		timestamp: node => node.getAttribute('datetime'),
+		url: node => node.closest('a')?.href,
+	},
+]);
+
+fixer.start();

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Uniform Timezone Extension",
-	"version": "0.0.15",
+	"version": "0.0.16",
 	"description": "Brings standardization to social media posts' dates and times.",
 	"homepage_url": "https://github.com/bellingcat/uniform-timezone",
 	"manifest_version": 3,

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -53,7 +53,12 @@
 		"js": ["js/timezone-fixers/linkedin.js"],
 		"css": ["css/hover-popup.css"],
 		"run_at": "document_end"
-	}],
+	}, {
+		"matches": ["https://www.threads.com/*"],
+		"js": ["js/timezone-fixers/threads.js"],
+		"css": ["css/hover-popup.css"],
+		"run_at": "document_end"
+    }],
 	"action": {
 		"default_popup": "html/popup.html"
 	},
@@ -63,7 +68,7 @@
 	},
 	"web_accessible_resources": [{
 		"resources": ["img/icon-128.png"],
-		"matches": ["https://twitter.com/*", "https://*.tiktok.com/*", "https://x.com/*", "https://*.x.com/*", "https://web.archive.org/*", "https://discord.com/*", "https://*.instagram.com/*", "https://bsky.app/*", "https://www.linkedin.com/*"]
+		"matches": ["https://twitter.com/*", "https://*.tiktok.com/*", "https://x.com/*", "https://*.x.com/*", "https://web.archive.org/*", "https://discord.com/*", "https://*.instagram.com/*", "https://bsky.app/*", "https://www.linkedin.com/*", "https://www.threads.com/*"]
 	}],
 	"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh1mCI9IkJLVJNEYZxa/OzIS13t3UGLlXwTyISY8i0Ouy8y1NG2k0qJSX9rtbZq6DKxl+JsHyvSzOVxb8SDj4FYmdOk0URqDGzTZYJqGuWUsJ4WQJ/mHsBa/33Xvvmp+qAc5MXWzt7lGK4s9RRSy61WDxmEdKb0aqZM2zvnmOv0E7V8KpUEMVrwyrfSbiZjz6EGusrSqIhQDVijt/VQS9zUJ1jLRNcoa5PcIYPRHAr3N0IXvZeLP1Q6rtd81FXZqocHYb+HP8v5bUyfXKpuVWxNI8Bpd66dr4bdGFueVJcUg0QuR06TKfon8NWHh+iKEH6SzDmAD2yJTtqHweheZU4QIDAQAB"
 }


### PR DESCRIPTION
Hi,

This PR adds support for threads. It is pretty straightforward and reuse the same code as Twitter that just hook any time frame and get the timestamp for it, and it seems to work reliably for any post : 
<img width="686" height="467" alt="Screen Capture_select-area_20260218234639" src="https://github.com/user-attachments/assets/66d55784-0bd1-4578-b479-6a524ee26296" />

I don't think web archive works well on threads post so I haven't tried to implement it there.